### PR TITLE
command migrate-user: fix hash length parameter (dk=)

### DIFF
--- a/src/MigrateUserCommand.php
+++ b/src/MigrateUserCommand.php
@@ -66,7 +66,7 @@ class MigrateUserCommand extends Command {
 
             if ($function == 'pbkdf2') {
                 list ($algo, $iterations, $salt) = explode(':', $hash_function_salt[2]);
-                $length = (function_exists('hash')) ? strlen(hash($algo, '')) : 0;
+                $length = (function_exists('hash')) ? strlen(hash($algo, '', true)) : 0;
 
                 if ($iterations < PasswordCommand::MIN_ITERATIONS) {
                     $stderr->writeln('<error>Warning: PBKDF2 iterations too low.</error>');


### PR DESCRIPTION
Function `hash` wasn't used consistently, which led to the wrong
parameter in the output of `migrate-user`.

(a) In `src/MigrateUserCommand.php` it was invoked like
    `hash($algo, '')`, which is implicitly `hash($algo, '', false)` and
    hex-encodes the output.
(b) In `src/PasswordCommand.php` it is invoked like
    `hash($algo, '', true)`, which outputs raw binary data.

See also <https://www.php.net/manual/en/function.hash.php>.

This commit adjusts (a) to (b).