### PR TITLE
Update passwd command to produce SimpleID 1.x passwords

### DIFF
--- a/src/Command/PasswordCommand.php
+++ b/src/Command/PasswordCommand.php
@@ -43,6 +43,7 @@ class PasswordCommand extends Command {
         $this->addOption('algorithm', 'f', InputOption::VALUE_REQUIRED, 'HMAC algorithm', 'sha256');
         $this->addOption('iterations', 'c', InputOption::VALUE_REQUIRED, 'Number of iterations', self::DEFAULT_ITERATIONS);
         $this->addOption('key-length', 'd', InputOption::VALUE_REQUIRED, 'Length of output, with 0 being the full length', 0);
+        $this->addOption('simpleid1', null, InputOption::VALUE_NONE, 'Output the encoded password in SimpleID 1.x format');
     }
 
     public function execute(InputInterface $input, OutputInterface $output) {
@@ -95,10 +96,18 @@ class PasswordCommand extends Command {
             return 1;
         }
 
-        $salt = random_bytes(32);
+        if ($input->getOption('simpleid1')) {
+            // SimpleID 1.x stores the salt as plain text, so we need to ensure that
+            // they are sensible ASCII characters
+            $salt = bin2hex(random_bytes(32));
+        } else {
+            $salt = random_bytes(32);
+        }
+
+        
         $hash = $this->hash_pbkdf2($algo, $password, $salt, $iterations, $length, true);
 
-        $output->writeln(self::encode_hash($hash, $salt, $algo, $iterations, $length));
+        $output->writeln(self::encode_hash($hash, $salt, $algo, $iterations, $length, $input->getOption('simpleid1')));
 
         return 0;
     }
@@ -128,10 +137,15 @@ class PasswordCommand extends Command {
         return substr(($raw_output) ? $result : bin2hex($result), 0, $length);
     }
 
-    static function encode_hash($hash, $salt, $algo, $iterations, $length = 0) {
+    static function encode_hash($hash, $salt, $algo, $iterations, $length = 0, $simpleid1_format = false) {
         $params = array('f' => $algo, 'c' => $iterations);
         if ($length > 0) $params['dk'] = $length;
-        return '$pbkdf2$' . http_build_query($params) . '$' . base64_encode($hash) . '$' . base64_encode($salt);
+
+        if ($simpleid1_format) {
+            return bin2hex($hash) . ':pbkdf2:' . $algo . ':' . $iterations . ':' . $salt;
+        } else {
+            return '$pbkdf2$' . http_build_query($params) . '$' . base64_encode($hash) . '$' . base64_encode($salt);
+        }
     }
 }
 


### PR DESCRIPTION
SimpleID 1.x can take PBKDF2 password hashes on a properly configured PHP installation, but the encoded password is formatted differently to Simple 2.x.

This PR adds a `--simpleid1` option to the `passwd` command to produce encoded passwords in the SimpleID 1.x format.