### PR TITLE
Add support for API commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
         "php": "^7.3 || ^8.0",
         "ext-hash": "*",
         "mustangostang/spyc": "~0.6",
-        "symfony/console": "^5.0 || ^6.0"
+        "symfony/console": "^5.0 || ^6.0",
+        "symfony/process": " ^5.4 || ^6.0"
     },
     "require-dev": {
         "consolidation/robo": "^3.0 || ^4.0",

--- a/src/Command/API/AbstractAPICommand.php
+++ b/src/Command/API/AbstractAPICommand.php
@@ -43,7 +43,7 @@ abstract class APICommand extends Command {
         $php_path = $php_finder->find();
 
         $command_line = $php_path . ' index.php ' . $command;
-        $working_dir = $input->getOption('algorithm');
+        $working_dir = $input->getOption('simpleid-dir');
 
         $process = Process::fromShellCommandline($command_line, $working_dir);
         $exit_code = $process->run(null, ['SIMPLEID_TOOL' => 'TRUE']);

--- a/src/Command/API/AbstractAPICommand.php
+++ b/src/Command/API/AbstractAPICommand.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * SimpleID
+ *
+ * Copyright (C) Kelvin Mo 2023
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+namespace SimpleIDTool\Command\API;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\PhpExecutableFinder;
+
+/**
+ * Abstract class for commands that call the SimpleID API
+ */
+abstract class APICommand extends Command {
+
+    protected function configure() {
+        parent::configure();
+        $this->addOption('simpleid-dir', 'd', InputOption::VALUE_REQUIRED, 'Directory containing SimpleID index.php', getcwd());
+    }
+
+    public function runSimpleID(string $command, InputInterface $input) {
+        $php_finder = new PhpExecutableFinder();
+        $php_path = $php_finder->find();
+
+        $command_line = $php_path . ' index.php ' . $command;
+        $working_dir = $input->getOption('algorithm');
+
+        $process = Process::fromShellCommandline($command_line, $working_dir);
+        $exit_code = $process->run(null, ['SIMPLEID_TOOL' => 'TRUE']);
+
+        // TODO: Parse $exit_code and $process->getOutput())
+        return [
+            'exit_code' => $exit_code,
+            'output' => $process->getOutput()
+        ]
+    }
+}
+
+?>

--- a/src/Command/Migration/MigrateConfigCommand.php
+++ b/src/Command/Migration/MigrateConfigCommand.php
@@ -29,9 +29,13 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Command to migrate configuration from SimpleID 1 to SimpleID 2
+ * format
+ */
 class MigrateConfigCommand extends Command {
 
-    private $option_map = array(
+    private $option_map = [
         'SIMPLEID_BASE_URL' => 'canonical_base_path',
         'SIMPLEID_IDENTITIES_DIR' => 'identities_dir',
         'SIMPLEID_STORE_DIR' => 'store_dir',
@@ -41,16 +45,16 @@ class MigrateConfigCommand extends Command {
         'SIMPLEID_LOCALE' => 'locale',
         'SIMPLEID_DATE_TIME_FORMAT' => 'date_time_format',
         'SIMPLEID_LOGFILE' => 'log_file'
-    );
+    ];
 
-    private $log_level_map = array('critical', 'error', 'warning', 'notice', 'info', 'debug');
+    private $log_level_map = [ 'critical', 'error', 'warning', 'notice', 'info', 'debug' ];
 
-    private $additional_config = array(
+    private $additional_config = [
         'temp_dir' => '/tmp',
         'webfinger_access_control_allow_origin' => '*',
         'acr' => 1,
         'logger' => 'SimpleID\Util\DefaultLogger',
-        'modules' => array(
+        'modules' => [
             'SimpleID\Base\MyModule',
             'SimpleID\Auth\PasswordAuthSchemeModule',
             'SimpleID\Auth\RememberMeAuthSchemeModule',
@@ -62,9 +66,12 @@ class MigrateConfigCommand extends Command {
             'SimpleID\Protocols\Connect\ConnectModule',
 //            'SimpleID\Protocols\Connect\ConnectSessionModule',
             'SimpleID\Protocols\Connect\ConnectClientRegistrationModule',
-        )
-    );
+        ]
+    ];
 
+    /**
+     * {@inheritdoc}
+     */
     protected function configure() {
         parent::configure();
         $this->setName('migrate:config')->setDescription('Converts a SimpleID 1 configuration file to SimpleID 2');
@@ -72,6 +79,9 @@ class MigrateConfigCommand extends Command {
         $this->addArgument('output', InputArgument::OPTIONAL, 'Output file name, or STDOUT if missing');
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function execute(InputInterface $input, OutputInterface $output) {
         $stderr = ($output instanceof ConsoleOutputInterface) ? $output->getErrorOutput() : $output;
 

--- a/src/Command/Migration/MigrateUserCommand.php
+++ b/src/Command/Migration/MigrateUserCommand.php
@@ -27,9 +27,13 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Command to migrate identity files from SimpleID 1 to SimpleID 2
+ * format
+ */
 class MigrateUserCommand extends Command {
 
-    private $sreg_map = array(
+    private $sreg_map = [
         'nickname'=> 'nickname',
         'email'=> 'email',
         'fullname'=> 'name',
@@ -37,8 +41,11 @@ class MigrateUserCommand extends Command {
         'gender'=> 'gender',
         'language'=> 'locale',
         'timezone'=> 'zone_info'
-    );
+    ];
 
+    /**
+     * {@inheritdoc}
+     */
     protected function configure() {
         parent::configure();
         $this->setName('migrate:user')->setDescription('Converts a SimpleID 1 identity file to a SimpleID 2 user file');
@@ -46,6 +53,9 @@ class MigrateUserCommand extends Command {
         $this->addArgument('output', InputArgument::OPTIONAL, 'Output file name, or STDOUT if missing');
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function execute(InputInterface $input, OutputInterface $output) {
         $stderr = ($output instanceof ConsoleOutputInterface) ? $output->getErrorOutput() : $output;
 

--- a/src/Command/Standalone/PasswordCommand.php
+++ b/src/Command/Standalone/PasswordCommand.php
@@ -36,6 +36,9 @@ class PasswordCommand extends Command {
     const MIN_ITERATIONS = 4096;
     const DEFAULT_ITERATIONS = 100000;
 
+    /**
+     * {@inheritdoc}
+     */
     protected function configure() {
         parent::configure();
         $this->setName('passwd')->setDescription('Encodes a password');
@@ -46,6 +49,9 @@ class PasswordCommand extends Command {
         $this->addOption('simpleid1', null, InputOption::VALUE_NONE, 'Output the encoded password in SimpleID 1.x format');
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function execute(InputInterface $input, OutputInterface $output) {
         $algo = $input->getOption('algorithm');
         if (!in_array($algo, hash_algos())) {
@@ -117,8 +123,24 @@ class PasswordCommand extends Command {
         return 0;
     }
 
+    /**
+     * Encodes a PBKDF2 hashed password for use in a SimpleID identity file.
+     * 
+     * This function can return the encoded hashed password in either SimpleID 1 or
+     * SimpleID 2 format.  For SimpleID 1, the `$hash` parameter should be a hexadecimal
+     * string.  For SimpleID 2, the `$hash` parameter should be a binary string.
+     * 
+     * @param string $hash the hashed password
+     * @param string $salt the salt as a binary string
+     * @param string $algo the HMAC algorithm
+     * @param int $iterations the number of iterations used in hashing the password
+     * @param int $length the length of the PBKDF2 output
+     * @param bool $simpleid1_format true to return the encoded hashed password in
+     * SimpleID 1 format
+     * @return string the encoded hashed password
+     */
     static function encode_hash($hash, $salt, $algo, $iterations, $length = 0, $simpleid1_format = false) {
-        $params = array('f' => $algo, 'c' => $iterations);
+        $params = [ 'f' => $algo, 'c' => $iterations ];
         if ($length > 0) $params['dk'] = $length;
 
         if ($simpleid1_format) {
@@ -128,7 +150,6 @@ class PasswordCommand extends Command {
         }
     }
 }
-
 
 
 ?>


### PR DESCRIPTION
Add support for commands for calling the API of a SimpleID installation.

This uses Fat-Free Framework support for [command-line mode] to call routes, with parameters if required.

[command-line mode]: https://fatfreeframework.com/3.8/routing-engine#RoutinginCLImode